### PR TITLE
Compatibility with pandas 0.15.1 and Spark 1.2.0

### DIFF
--- a/sparklingpandas/test/pandas_groupby_tests.py
+++ b/sparklingpandas/test/pandas_groupby_tests.py
@@ -12,7 +12,6 @@ import sys
 import pandas as pd
 from pandas import date_range, bdate_range, Timestamp
 from pandas.core.index import Index, MultiIndex, Int64Index
-from pandas.core.common import rands
 from pandas.core.api import Categorical, DataFrame
 from pandas.core.series import Series
 from pandas.util.testing import (assert_panel_equal, assert_frame_equal,
@@ -26,6 +25,12 @@ from pandas import compat
 import pandas.util.testing as tm
 import unittest2
 import numpy as np
+
+try:
+    # rands was moved to util.testing in pandas 0.15
+    from pandas.core.common import rands
+except ImportError:
+    from pandas.util.testing import rands
 
 
 class PandasGroupby(SparklingPandasTestCase):

--- a/sparklingpandas/utils.py
+++ b/sparklingpandas/utils.py
@@ -1,20 +1,31 @@
 """
 Simple common utils shared between the sparklingpandas modules
 """
+import sys
+import os
+
+from glob import glob
 
 
 def add_pyspark_path():
-    """
-    Add PySpark to the library path based on the value of SPARK_HOME
-    """
-    import sys
-    import os
+    """Add PySpark to the library path based on the value of SPARK_HOME. """
 
     try:
-        sys.path.append(os.environ['SPARK_HOME'] + "/python")
-        sys.path.append(os.environ['SPARK_HOME'] +
-                        "/python/lib/py4j-0.8.1-src.zip")
+        spark_home = os.environ['SPARK_HOME']
+
+        sys.path.append(os.path.join(spark_home, 'python'))
+        py4j_src_zip = glob(os.path.join(spark_home, 'python',
+                                         'lib', 'py4j-*-src.zip'))
+        if len(py4j_src_zip) == 0:
+            raise ValueError('py4j source archive not found in %s'
+                             % os.path.join(spark_home, 'python', 'lib'))
+        else:
+            py4j_src_zip = sorted(py4j_src_zip)[::-1]
+            sys.path.append(py4j_src_zip[0])
     except KeyError:
-        print """SPARK_HOME was not set. please set it. e.g.
-        SPARK_HOME='/home/...' ./bin/pyspark [program]"""
+        print("""SPARK_HOME was not set. please set it. e.g.
+        SPARK_HOME='/home/...' ./bin/pyspark [program]""")
+        exit(-1)
+    except ValueError as e:
+        print(str(e))
         exit(-1)


### PR DESCRIPTION
pandas moved the ``rands`` method recently to a different package; I added a conditional import so that it works on 0.14 and 0.15 .

The version of py4j is currently hardcoded; I added a glob to include the most recent version, however, running the tests using Spark 1.2.0 causes one test failure ``test_to_spark_sql`` .